### PR TITLE
Small updates and fixes

### DIFF
--- a/samples/with-shell-navigation/appconfig.json
+++ b/samples/with-shell-navigation/appconfig.json
@@ -4,7 +4,6 @@
   "description": "Sample extension inside Shell with Shell navigation",   
   "version": "1.0.0", 
   "icon": "https://raw.githubusercontent.com/SAP-samples/fsm-extension-sample/master/samples/with-shell-navigation/icon.png",
-  "lang": "en",
   "translations": [
     {
       "lang": "de",

--- a/samples/without-shell-navigation/appconfig.json
+++ b/samples/without-shell-navigation/appconfig.json
@@ -4,7 +4,6 @@
   "description": "Sample extension inside Shell without Shell navigation",   
   "version": "1.0.0", 
   "icon": "https://raw.githubusercontent.com/SAP-samples/fsm-extension-sample/master/samples/without-shell-navigation/icon.png",
-  "lang": "en",
   "translations": [
     {
       "lang": "de",

--- a/samples/without-shell-navigation/router.js
+++ b/samples/without-shell-navigation/router.js
@@ -28,7 +28,7 @@ const router = () => {
 
   if (PATH === '/') {
     // Rerouting in case of "/" to /#/first-level-1
-    window.location.href = window.location.origin + '/#/first-level-1';
+    window.location.href = window.location.origin + window.location.pathname + '#/first-level-1';
   } else {
     const SECTION_ID = determineSectionID(PATH, ROUTES); // Determine ID of the section, which belongs to the new route
     const MAIN_SECTION = document.getElementById('extension-main');


### PR DESCRIPTION
Fix rerouting for sample without shell navigation

Remove property 'lang' from appconfig.json as it is not used. Values stored inside the properties description and name are always treated as English.