### PR TITLE
updating the name of the product

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# SAP Field Service Management - Sample Extensions
+# SAP Field Service and Asset Management - Sample Extensions
 
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP-samples/fsm-extension-sample)](https://api.reuse.software/info/github.com/SAP-samples/fsm-extension-sample)
 
-This repository contains samples that demonstrate the API usage patterns for SAP Field Service Management extensions. These code samples are created to help developers start building extensions and are designed to run on any platform.
+This repository contains samples that demonstrate the API usage patterns for SAP Field Service and Asset Management extensions. These code samples are created to help developers start building extensions and are designed to run on any platform.
 
-You can find more information about the SAP Field Service Management API and the extensions concept in the [SAP Field Service Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US).
+You can find more information about the SAP Field Service and Asset Management API and the extensions concept in the [SAP Field Service and Asset Management Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US).
 
 ## Disclaimer
 
@@ -12,7 +12,7 @@ Do not use the samples or parts of them in your productive code. The samples are
 
 ## Prerequisite for Using the Samples
 
-To run the sample extensions, you need access to SAP Field Service Management. You can find more information about getting access in the [SAP Field Service Management – SAP Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US).
+To run the sample extensions, you need access to SAP Field Service and Asset Management. You can find more information about getting access in the [SAP Field Service and Asset Management – SAP Help Portal](https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US).
 
 ## Using the Samples
 

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "FSM-extension-sample",
-  "description": "Demonstrate the API usage patterns for extensions within the SAP Field Service Management application.",
+  "description": "Demonstrate the API usage patterns for extensions within the SAP Field Service and Asset Management application.",
   "website": "https://help.sap.com/viewer/fsm_extensions/Cloud/en-US",
   "repository": "https://github.com/SAP-samples/fsm-extension-sample",
   "logo": "https://raw.githubusercontent.com/SAP-samples/fsm-extension-sample/master/samples/service-contract/icon.png",

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -1,21 +1,21 @@
 # Authentication within an extension
 
-This documentation page explains how to secure your SAP FSM extension using authentication.
+This documentation page explains how to secure your SAP Field Service and Asset Management extension using authentication.
 It only describes one possible implementation which is the recommended **OpenID Connect OAuth code flow**, but can be adjusted to fit specific needs.
 
-The **OpenID Connect OAuth code flow** requires an extension to run a backend server which will provide secure APIs to fetch the SAP FSM objects. This backend will:
+The **OpenID Connect OAuth code flow** requires an extension to run a backend server which will provide secure APIs to fetch the SAP Field Service and Asset Management objects. This backend will:
 
-- Store client credentials to access the SAP FSM APIs and manage the SAP FSM OAuth access token
+- Store client credentials to access the SAP Field Service and Asset Management APIs and manage the OAuth2 access token
 - Receive the OpenID Connect credential from an Identity Provider (IdP)
 - Ensure that the connected SSO user is the same as the one running the extension within shell
 - Provide a token mechanism to identify a user inside the extension
-- Perform requests on behalf of a user to the SAP FSM APIs with the extension OAuth access token.
+- Perform requests on behalf of a user to the SAP Field Service and Asset Management APIs with the extension OAuth access token.
 
 ## 1. OAuth 2.0 Client credentials
 
-The backend needs to securely store client credentials to identify itself with FSM as described in the [SAP FSM OAuth API documentation](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_access_api/oauth-intro.html).
+The backend needs to securely store client credentials to identify itself with SAP Field Service and Asset Management as described in the [OAuth2 API documentation](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_access_api/oauth-intro.html).
 
-Such credentials can be created by a SUPERUSER role at **Admin > Account > Clients**. It can also define API authorizations to limit access with specific permissions. See [FSM Help portal - Generating Client ID & Secret](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_admin/generating-client-id.html) for more details on how to.
+Such credentials can be created by a SUPERUSER role at **Admin > Account > Clients**. It can also define API authorizations to limit access with specific permissions. See [SAP Field Service and Asset Management Help portal - Generating Client ID & Secret](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_admin/generating-client-id.html) for more details on how to.
 
 ```bash
 FSM_CLIENT_ID=<CLIENT_ID_PROVIDED_BY_ADMINISTRATOR>
@@ -24,13 +24,13 @@ FSM_CLIENT_SECRET=<CLIENT_SECRET_PROVIDED_BY_ADMINISTRATOR>
 
 Credentials are attached to a unique cluster and account name. An extension might need to handle multiple accounts, so it needs credentials for each of those accounts.
 
-To fetch protected data, it will be needed to exchange those credentials with an OAuth access_token which will be used for all users. Extensions need to log all requests for identification as FSM will only identify the extension and not the user.
+To fetch protected data, it will be needed to exchange those credentials with an OAuth access_token which will be used for all users. Extensions need to log all requests for identification as SAP Field Service and Asset Management will only identify the extension and not the user.
 
 ## 2. OpenID Connect for users
 
 Authentication within an extension requires implementing a communication protocol with an identity provider (IdP). This example uses the **OAuth 2.0 OpenID Connect protocol** with the **SAP Identity provider**.
 
-Both SAP FSM and the IdP will use the **email** as `NAMEID` to identify a user.
+Both SAP Field Service and Asset Management and the IdP will use the **email** as `NAMEID` to identify a user.
 
 An extension needs to be registered to the IdP and identified using **IdP client credentials**
 
@@ -52,23 +52,23 @@ Multiple libraries offer high level implementation of the OAuth OpenID protocol.
 On login, the extension will redirect the user to the IdP for identification, then redirect to the `IDP_URL_CALLBACK` with the authorization code.
 Passport will exchange this code on the backend side with the IdP to return the **user jwttoken** containing the user email.
 
-## 3. Connect user accounts between IdP and FSM
+## 3. Connect user accounts between IdP and SAP Field Service and Asset Management
 
-To identify a user request, FSM provides in context the **cluster url, account name, and user id**.
+To identify a user request, SAP Field Service and Asset Management provides in context the **cluster url, account name, and user id**.
 Those values can be fetched with the [ShellSDK](https://github.com/SAP/fsm-shell) library, using the **require_context** event.
 
-Using the client credentials to get an access token, an extension can fetch the FSM user profile as described in [USER ID](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_user_api/user-api-overview.html) to **verify if the FSM user email matches the IdP email value**.
+Using the client credentials to get an access token, an extension can fetch the SAP Field Service and Asset Management user profile as described in [USER ID](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_user_api/user-api-overview.html) to **verify if the SAP Field Service and Asset Management user email matches the IdP email value**.
 
 When both profiles match, a **session token can be assigned to the user** to access the extension API and ensure authentication.
 
 ## 4. Session token
 
-**FSM Client credentials and OAuth access token must never be communicated to the front-end application** and only be stored within the backend.
+**SAP Field Service and Asset Management Client credentials and OAuth access token must never be communicated to the front-end application** and only be stored within the backend.
 
 You are free to use any authentication mechanism to protect your APIs. Passportjs provides a simple **bearer token authentication** mechanism which can be easily used for demo purposes.
 
-## 5. Fetch FSM APIs using the OAuth token
+## 5. Fetch SAP Field Service and Asset Management APIs using the OAuth2 token
 
-FSM APIs require **context headers** when fetching data. Those headers provided by the [ShellSDK](https://github.com/SAP/fsm-shell) should then be required at the extension API level too.
+SAP Field Service and Asset Management APIs require **context headers** when fetching data. Those headers provided by the [ShellSDK](https://github.com/SAP/fsm-shell) should then be required at the extension API level too.
 
-More details regarding FSM APIs within the [SAP FSM Help portal - API documentation](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT#discover_task-development).
+More details regarding SAP Field Service and Asset Management APIs within the [API documentation](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT#discover_task-development).

--- a/docs/Extension-on-SAP-Build.md
+++ b/docs/Extension-on-SAP-Build.md
@@ -12,7 +12,7 @@
 
 ![Create new project 1](./assets/ExtensionOnSapBuild/create-project-step1.png)
 
-- For simplicity, we are not going to create a new project from scratch. In instead, we are providing a FSM-Extension sample template that covers some of the fundaments when developing an FSM extension. Please download it from [here](https://github.com/SAP-samples/fsm-extension-sample/blob/main/docs/assets/ExtensionOnSapBuild/FSM-Extension.zip.gpg) and save it on your computer.
+- For simplicity, we are not going to create a new project from scratch. In instead, we are providing an FSM-Extension sample template that covers some of the fundaments when developing an extension for SAP Field Service and Asset Management. Please download it from [here](https://github.com/SAP-samples/fsm-extension-sample/blob/main/docs/assets/ExtensionOnSapBuild/FSM-Extension.zip.gpg) and save it on your computer.
 
 - In the SAP build lobby, choose **import**:
 
@@ -70,9 +70,9 @@
 
 ![Deploy and test 4](./assets/ExtensionOnSapBuild/deploy-and-test-project-step4.png)
 
-## Step 4: Register the FSM Extension in SAP Field Service Management
+## Step 4: Register the SAP Field Service and Asset Management Extension in SAP Field Service and Asset Management
 
-- Login to SAP Field Service Management and open the **Foundational Services** application, then navigate to **Extensions** > **Installed**, and choose **Add Extension**:
+- Login to SAP Field Service and Asset Management and open the **Foundational Services** application, then navigate to **Extensions** > **Installed**, and choose **Add Extension**:
 
 ![Register extension 1](./assets/ExtensionOnSapBuild/register-extension-step1.png)
 
@@ -100,6 +100,6 @@
 
 ![Register extension 7](./assets/ExtensionOnSapBuild/register-extension-step7.png)
 
-- The FSM-Extension sample template should be loaded and displaying information from SAP Field Service Management:
+- The FSM-Extension sample template should be loaded and displaying information from SAP Field Service and Asset Management:
 
 ![Register extension 8](./assets/ExtensionOnSapBuild/register-extension-step8.png)

--- a/docs/ExtensionOnSAP-CP-UI5.md
+++ b/docs/ExtensionOnSAP-CP-UI5.md
@@ -68,7 +68,7 @@ sap.ui.loader.config({
 
 ![Consuming shellSDK 1](./assets/ExtensionOnSapCP-UI5/consuming-shellSDK-step1.png)
 
-- To establish a communication with the SAP Field Service Management Shell host, you need to initialize the client library and send a ```REQUIRE_CONTEXT``` event. For more information, see **[ShellSDK - Library usage sample](https://sap.github.io/fsm-shell/#/usage-sample?id=sending-event-to-the-shell-host-application)**. Copy and paste the following code in the file ```/ui5extension/webapp/controller/View1.controller.js```:
+- To establish a communication with the SAP Field Service and Asset Management Shell host, you need to initialize the client library and send a ```REQUIRE_CONTEXT``` event. For more information, see **[ShellSDK - Library usage sample](https://sap.github.io/fsm-shell/#/usage-sample?id=sending-event-to-the-shell-host-application)**. Copy and paste the following code in the file ```/ui5extension/webapp/controller/View1.controller.js```:
 
 ```javascript
 sap.ui.define([
@@ -92,7 +92,7 @@ return Controller.extend("ui5extension.controller.View1", {
 
 ![Consuming shellSDK 2](./assets/ExtensionOnSapCP-UI5/consuming-shellSDK-step2.png)
 
-- To display some data pulled from SAP Field Service Management, let's change the template view generated within the project. Replace the content in the file ```/ui5extension/webapp/view/View1.view.xml``` with the following code:
+- To display some data pulled from SAP Field Service and Asset Management, let's change the template view generated within the project. Replace the content in the file ```/ui5extension/webapp/view/View1.view.xml``` with the following code:
 
 ```xml
 <mvc:View controllerName="ui5extension.controller.View1"
@@ -177,9 +177,9 @@ return Controller.extend("ui5extension.controller.View1", {
 
 ![Building, deploying, and testing 3](./assets/ExtensionOnSapCP-UI5/build-deploy-and-test-step3.png)
 
-## Step 4: Register the SAPUI5 Application as an extension in SAP Field Service Management
+## Step 4: Register the SAPUI5 Application as an extension in SAP Field Service and Asset Management
 
-- Login to SAP Field Service Management and open the **Foundational Services** application, then navigate to **Extensions** > **Installed**, and choose **Add Extension**:
+- Login to SAP Field Service and Asset Management and open the **Foundational Services** application, then navigate to **Extensions** > **Installed**, and choose **Add Extension**:
 
 ![Registering, consuming SAP UI5 app 1](./assets/ExtensionOnSapCP-UI5/register-consume-ui5-app-step1.png)
 
@@ -207,6 +207,6 @@ return Controller.extend("ui5extension.controller.View1", {
 
 ![Registering, consuming SAP UI5 app 7](./assets/ExtensionOnSapCP-UI5/register-consume-ui5-app-step7.png)
 
-- The SAPUI5 should be loaded as an extension and displaying information from SAP Field Service Management:
+- The SAPUI5 should be loaded as an extension and displaying information from SAP Field Service and Asset Management:
 
 ![Registering, consuming SAP UI5 app 8](./assets/ExtensionOnSapCP-UI5/register-consume-ui5-app-step8.png)

--- a/samples/extension-starter-kit/README.md
+++ b/samples/extension-starter-kit/README.md
@@ -1,6 +1,6 @@
-# SAP Field Service Management Extension Starter Kit
+# SAP Field Service and Asset Management Extension Starter Kit
 
-This is an SAP Field Service Management extension project configured for quick-start development with contemporary tooling. The setup utilizes TypeScript and Node.js, enabling TypeScript-based development with npm package management. Pre-configured npm scripts handle the TypeScript compilation process and serve the resulting application files (HTML, CSS, and JavaScript) through a secure tunnel, making them publicly accessible via HTTPS.
+This is an SAP Field Service and Asset Management extension project configured for quick-start development with contemporary tooling. The setup utilizes TypeScript and Node.js, enabling TypeScript-based development with npm package management. Pre-configured npm scripts handle the TypeScript compilation process and serve the resulting application files (HTML, CSS, and JavaScript) through a secure tunnel, making them publicly accessible via HTTPS.
 
 **Use this sample or parts of it in production environments at your own risk**. It should be used only as a reference, since it does not follow any particular security, performance, or quality standards.
 
@@ -24,7 +24,7 @@ The Ngrok publicly accessible URL should be displayed. This is an example how it
 
 ### Next Steps
 
-Now you copy the URL, and install it as an extension in the FSM Extension Management app. Anytime you change and save the content in the index.html, it will be automatically reflected in the UI. For more information about the manual installation and the placement of an extension application, please see the following references:
+Now you copy the URL, and install it as an extension in the SAP Field Service and Asset Management Extension Management app. Anytime you change and save the content in the index.html, it will be automatically reflected in the UI. For more information about the manual installation and the placement of an extension application, please see the following references:
 
 - [Manual Installation of an Extension](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_extensions/install-manually.html)
 - [Placing an Extension App](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_extensions/place-an-extension-app.html)

--- a/samples/extension-starter-kit/public/appconfig.json
+++ b/samples/extension-starter-kit/public/appconfig.json
@@ -1,6 +1,6 @@
 {
-    "name": "FSM Extension Starter-Kit",
-    "provider": "SAP FSM",
+    "name": "SAP Field Service and Asset Management Extension Starter-Kit",
+    "provider": "SAP SE",
     "description": "Sample extension with a Starter-Kit",
     "version": "1.0.0",
     "icon": ""

--- a/samples/extension-starter-kit/public/index.html
+++ b/samples/extension-starter-kit/public/index.html
@@ -2,7 +2,7 @@
 <html lang="de">
 
 <head>
-    <title>FSM Extension Starter-Kit</title>
+    <title>SAP Field Service and Asset Management Extension Starter-Kit</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link href="index.css" rel="stylesheet">

--- a/samples/login-with-sso/frontend/configure-popup.html
+++ b/samples/login-with-sso/frontend/configure-popup.html
@@ -12,14 +12,14 @@
     </div>
     <div role="region" aria-labelledby="jhqDKYrt" class="fd-panel__content">
       <form onSubmit="saveForm(); return false;">
-        <h3>FSM client credentials</h3>
+        <h3>FSAP Field Service and Asset Management client credentials</h3>
         <p>Client credentials need to be define by a SUPERUSER within the administration.</p>
         <div class="fd-form-item">
-          <label class="fd-form-label" for="input-1">FSM Client ID:</label>
+          <label class="fd-form-label" for="input-1">Client ID:</label>
           <input class="fd-input" type="text" id="input-1" placeholder="">
         </div>
         <div class="fd-form-item">
-          <label class="fd-form-label" for="input-2">FM Client Secret:</label>
+          <label class="fd-form-label" for="input-2">Client Secret:</label>
           <input class="fd-input" type="text" id="input-2" placeholder="">
         </div>
         <h3>Identity provider</h3>

--- a/samples/login-with-sso/frontend/configure.html
+++ b/samples/login-with-sso/frontend/configure.html
@@ -11,7 +11,7 @@
       <h3>Configure your extension</h3>
       <p>You now need to provide client credentials to your extension so it can access your data.</p>
       <p><em></em></p>
-      <p>More details about client credentials can be found on the <a href="https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US" target="_blank">SAP Field Service Management help portal</a>.</p>
+      <p>More details about client credentials can be found on the <a href="https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US" target="_blank">SAP Field Service and Asset Management help portal</a>.</p>
       <p><button id="configure" disabled="disabled" class="fd-button fd-button--emphasized" onClick="openPopup()">Configure</button></p>
     </div>
   </div>

--- a/samples/login-with-sso/frontend/index.html
+++ b/samples/login-with-sso/frontend/index.html
@@ -13,7 +13,7 @@
       </div>
       <div role="region" aria-labelledby="jhqDKYrt" class="fd-panel__content">
         <p>Thanks for running <strong>login-with-sso</strong> sample from our <a href="https://github.com/SAP-samples/fsm-extension-sample">fsm-extension-sample</a> repository.</p>
-        <p>This extension has been designed to run within SAP Field Service Management and now needs to be installed as describe within the <a href="https://help.sap.com/viewer/fsm_extensions/LATEST/en-US/overview.html">FSM Help Portal - Extensions</a>.</p>
+        <p>This extension has been designed to run within SAP Field Service and Asset Management and now needs to be installed as describe within the <a href="https://help.sap.com/viewer/fsm_extensions/LATEST/en-US/overview.html">SAP Field Service and Asset Management Help Portal - Extensions</a>.</p>
       </div>
     </div>
   </div>

--- a/samples/login-with-token/frontend/configure.html
+++ b/samples/login-with-token/frontend/configure.html
@@ -11,7 +11,7 @@
       <h3>Configure your extension</h3>
       <p>You now need to provide client credentials to your extension so it can access your data.</p>
       <p><em></em></p>
-      <p>More details about client credentials can be found on the <a href="https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US" target="_blank">SAP Field Service Management help portal</a>.</p>
+      <p>More details about client credentials can be found on the <a href="https://help.sap.com/viewer/product/SAP_FIELD_SERVICE_MANAGEMENT/Cloud/en-US" target="_blank">SAP Field Service and Asset Management help portal</a>.</p>
       <p><button id="configure" disabled="disabled" class="fd-button fd-button--emphasized" onClick="openPopup()">Configure</button></p>
     </div>
   </div>

--- a/samples/login-with-token/frontend/index.html
+++ b/samples/login-with-token/frontend/index.html
@@ -13,7 +13,7 @@
       </div>
       <div role="region" aria-labelledby="jhqDKYrt" class="fd-panel__content">
         <p>Thanks for running <strong>login-with-token</strong> sample from our <a href="https://github.com/SAP-samples/fsm-extension-sample">fsm-extension-sample</a> repository.</p>
-        <p>This extension has been designed to run within SAP Field Service Management and now needs to be installed as describe within the <a href="https://help.sap.com/viewer/fsm_extensions/LATEST/en-US/overview.html">FSM Help Portal - Extensions</a>.</p>
+        <p>This extension has been designed to run within SAP Field Service and Asset Management and now needs to be installed as describe within the <a href="https://help.sap.com/viewer/fsm_extensions/LATEST/en-US/overview.html">SAP Field Service and Asset Management Help Portal - Extensions</a>.</p>
       </div>
     </div>
   </div>

--- a/samples/mobile-web-container/README.md
+++ b/samples/mobile-web-container/README.md
@@ -38,7 +38,7 @@ To receive the access URL for the extension, you can use an external solution li
 
 ### Accessing the Web Container with the Extension
 
-1. On your mobile phone, open the SAP Field Service Management mobile application proceed with the login.
+1. On your mobile phone, open the SAP Field Service and Asset Management mobile application proceed with the login.
 2. From the burger menu, access the side menu.
 3. From the side menu, select the object type that you have chosen during the web container creation, for example, Equipment. A list of the respective object type is displayed.
 4. From the list, select an entry.

--- a/samples/parameter-showcase-extension/README.md
+++ b/samples/parameter-showcase-extension/README.md
@@ -1,6 +1,6 @@
 # Parameter Showcase Extension
 
-The Parameter Showcase Extension is a minimalist sample of a front-end extension that showcases the capability of FSM Extensions to ask the user for parameter when installing.
+The Parameter Showcase Extension is a minimalist sample of a front-end extension that showcases the capability of SAP Field Service and Asset Management Extensions to ask the user for parameter when installing.
 The data provided by the user during the installation is encrypted and stored within SAP FSM. The extension can access those values during runtime.
 
 It is designed to run within the [dispatching board](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_extensions/dispatching-board.html).

--- a/samples/parameter-showcase-extension/appconfig.json
+++ b/samples/parameter-showcase-extension/appconfig.json
@@ -1,6 +1,6 @@
 {
   "name": "Parameter Showcase",
-  "description": "Sample extension to showcase the parameter support for SAP FSM extensions.",
+  "description": "Sample extension to showcase the parameter support for SAP Field Service and Asset Management extensions.",
   "version": "0.1.0",
   "icon": "https://raw.githubusercontent.com/scamastral/sample-fsm-extensions/master/parameter-showcase-extension/parameter-icon.png",
   "useShellSDK": true,

--- a/samples/refresh-token-sample-js/README.md
+++ b/samples/refresh-token-sample-js/README.md
@@ -1,6 +1,6 @@
-# SAP Field Service Management - Refresh Token Sample (JavaScript)
+# SAP Field Service and Asset Management - Refresh Token Sample (JavaScript)
 
-This is an SAP Field Service Management extension project demonstrating how to handle token refresh and display authentication tokens in real-time using Javascript.
+This is an SAP Field Service and Asset Management extension project demonstrating how to handle token refresh and display authentication tokens in real-time using Javascript.
 
 **Do not use this samples or parts of your productive code**. It should be used only as a reference, since it does not follow any particular security, performance, or quality standards.
 **There will be no support if you use code from this project in your productive environment**.
@@ -12,14 +12,14 @@ This is an SAP Field Service Management extension project demonstrating how to h
 - **Module System**: ES Modules (ESNext)
 - **Development**: Hot Module Replacement (HMR) with instant reload
 - **Production**: Optimized build with code splitting and minification
-- **FSM Shell SDK**: Official SDK for FSM extensions. It handles authentication, context, and event communication with the FSM platform
+- **SAP Field Service and Asset Management Shell SDK**: Official SDK for SAP Field Service and Asset Management extensions. It handles authentication, context, and event communication with the SAP Field Service and Asset Management platform
 
 ## Working with the Sample
 
 ### Prerequisites
 
 - Node.js installed (v22 or higher recommended)
-- Access to SAP Field Service Management
+- Access to SAP Field Service and Asset Management
 
 ### Step by Step
 
@@ -60,7 +60,7 @@ refresh-token-sample-js/
 │   ├── index.js                  # Main application logic and UI updates
 │   ├── util/
 │   │   ├── util.js               # BehaviorSubject implementation
-│   │   └── shell-sdk.service.js  # FSM Shell SDK service wrapper
+│   │   └── shell-sdk.service.js  # SAP Field Service and Asset Management Shell SDK service wrapper
 │   └── styles/
 │       └── styles.css            # Application styles
 │

--- a/samples/refresh-token-sample-js/package.json
+++ b/samples/refresh-token-sample-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fsm-extension-refresh-token-sample-js",
   "version": "1.0.0",
-  "description": "FSM Extension - Refresh Token Sample (JavaScript + Vite)",
+  "description": "SAP Field Service and Asset Management Extension - Refresh Token Sample (JavaScript + Vite)",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/samples/refresh-token-sample-js/src/appconfig.json
+++ b/samples/refresh-token-sample-js/src/appconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "Refresh token sample (JavaScript)",
   "provider": "SAP FSM",
-  "description": "Sample extension to demo the refresh token functionality in FSM Shell SDK for JavaScript extensions.",   
+  "description": "Sample extension to demo the refresh token functionality in SAP Field Service and Asset Management Shell SDK for JavaScript extensions.",   
   "version": "1.0.0", 
   "icon": "https://upload.wikimedia.org/wikipedia/commons/d/d3/User_Circle.png"
 }

--- a/samples/refresh-token-sample-js/src/index.html
+++ b/samples/refresh-token-sample-js/src/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="./styles/styles.css">
-    <title>FSM Extension - Refresh Token Sample</title>
+    <title>SAP Field Service and Asset Management Extension - Refresh Token Sample</title>
   </head>
 
   <body>

--- a/samples/refresh-token-sample-ts/README.md
+++ b/samples/refresh-token-sample-ts/README.md
@@ -1,6 +1,6 @@
-# SAP Field Service Management - Refresh Token Sample (TypeScript)
+# SAP Field Service and Asset Management - Refresh Token Sample (TypeScript)
 
-This is an SAP Field Service Management extension project demonstrating how to handle token refresh and display authentication tokens in real-time using Typescript.
+This is an SAP Field Service and Asset Management extension project demonstrating how to handle token refresh and display authentication tokens in real-time using Typescript.
 
 **Do not use this samples or parts in your productive code**. It should be used only as a reference, since it does not follow any particular security, performance, or quality standards.
 **There will be no support if you use code from this project in your productive environment**.
@@ -12,14 +12,14 @@ This is an SAP Field Service Management extension project demonstrating how to h
 - **Module System**: ES Modules (ESNext)
 - **Development**: Hot Module Replacement (HMR) with instant reload
 - **Production**: Optimized build with code splitting and minification
-- **FSM Shell SDK**: Official SDK for FSM extensions. It handles authentication, context, and event communication with the FSM platform
+- **SAP Field Service and Asset Management Shell SDK**: Official SDK for SAP Field Service and Asset Management extensions. It handles authentication, context, and event communication with the SAP Field Service and Asset Management platform
 
 ## Working with the Sample
 
 ### Prerequisites
 
 - Node.js installed (v22 or higher recommended)
-- Access to SAP Field Service Management
+- Access to SAP Field Service and Asset Management
 
 ### Step by Step
 
@@ -60,7 +60,7 @@ refresh-token-sample-ts/
 │   ├── index.ts                  # Main application logic and UI updates
 │   ├── util/
 │   │   ├── util.ts               # BehaviorSubject implementation
-│   │   └── shell-sdk.service.ts  # FSM Shell SDK service wrapper
+│   │   └── shell-sdk.service.ts  # SAP Field Service and Asset Management Shell SDK service wrapper
 │   └── styles/
 │       └── styles.css            # Application styles
 │

--- a/samples/refresh-token-sample-ts/package.json
+++ b/samples/refresh-token-sample-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fsm-extension-refresh-token-sample",
   "version": "1.0.0",
-  "description": "FSM Extension - Refresh Token Sample (TypeScript + Vite)",
+  "description": "SAP Field Service and Asset Management Extension - Refresh Token Sample (TypeScript + Vite)",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/samples/refresh-token-sample-ts/src/appconfig.json
+++ b/samples/refresh-token-sample-ts/src/appconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "Refresh token sample (TypeScript)",
-  "provider": "SAP FSM",
-  "description": "Sample extension to demo the refresh token functionality in FSM Shell SDK for TypeScript extensions.",   
+  "provider": "SAP SE",
+  "description": "Sample extension to demo the refresh token functionality in SAP Field Service and Asset Management Shell SDK for TypeScript extensions.",   
   "version": "1.0.0", 
   "icon": "https://upload.wikimedia.org/wikipedia/commons/d/d3/User_Circle.png"
 }

--- a/samples/refresh-token-sample-ts/src/index.html
+++ b/samples/refresh-token-sample-ts/src/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="./styles/styles.css">
-    <title>FSM Extension - Refresh Token Sample</title>
+    <title>SAP Field Service and Asset Management Extension - Refresh Token Sample</title>
   </head>
 
   <body>

--- a/samples/refresh-token-sample-ui5/README.md
+++ b/samples/refresh-token-sample-ui5/README.md
@@ -1,6 +1,6 @@
-# SAP Field Service Management - Token Refresh Sample (SAP UI5)
+# SAP Field Service and Asset Management - Token Refresh Sample (SAP UI5)
 
-This is an SAP Field Service Management extension project demonstrating how to handle token refresh and display authentication tokens in real-time using SAP UI5.
+This is an SAP Field Service and Asset Management extension project demonstrating how to handle token refresh and display authentication tokens in real-time using SAP UI5.
 
 **Do not use this sample or parts in your productive code**. It should be used only as a reference, since it does not follow any particular security, performance, or quality standards.
 **There will not be support if you use code from this project in your productive environment**.
@@ -11,7 +11,7 @@ This is an SAP Field Service Management extension project demonstrating how to h
 - **Language**: TypeScript with strict mode
 - **UI Components**: SAP UI5 controls (TextArea, MessageStrip, etc.)
 - **Data Binding**: JSON Model for reactive UI updates
-- **FSM Shell SDK**: Official SDK for FSM extensions. It handles authentication, context, and event communication with the FSM platform
+- **SAP Field Service and Asset Management Shell SDK**: Official SDK for SAP Field Service and Asset Management extensions. It handles authentication, context, and event communication with the SAP Field Service and Asset Management platform
 - **UI Display**: Real-time token history with timestamps in a growing TextArea
 
 ## Working with the Sample
@@ -19,7 +19,7 @@ This is an SAP Field Service Management extension project demonstrating how to h
 ### Prerequisites
 
 - An account in SAP BTP
-- Access to SAP Field Service Management
+- Access to SAP Field Service and Asset Management
 
 ### Step by Step
 
@@ -45,7 +45,7 @@ This is an SAP Field Service Management extension project demonstrating how to h
 
    This generates optimized UI5 files ready for deployment.
 
-4. Deploy the extension to SAP FSM and access it through the FSM Shell to see token refresh in action
+4. Deploy the extension to SAP Field Service and Asset Management and access it through the SAP Field Service and Asset Management Shell to see token refresh in action
 
 ## Project Structure
 
@@ -68,7 +68,7 @@ token-refresh-sample-ui5/
 │   │   └── models.ts             # JSON model initialization
 │   │
 │   ├── util/                     # Utility services
-│   │   ├── shell-sdk.service.ts  # FSM Shell SDK service wrapper
+│   │   ├── shell-sdk.service.ts  # SAP Field Service and Asset Management Shell SDK service wrapper
 │   │   └── util.ts               # Common utilities
 │   │
 │   ├── i18n/                     # Internationalization

--- a/samples/refresh-token-sample-ui5/netlify.toml
+++ b/samples/refresh-token-sample-ui5/netlify.toml
@@ -4,7 +4,7 @@
   publish = "dist"
   command = "npm run build"
 
-# CORS headers to allow FSM Shell to load the extension
+# CORS headers to allow SAP Field Service and Asset Management Shell to load the extension
 [[headers]]
   for = "/*"
   [headers.values]

--- a/samples/refresh-token-sample-ui5/webapp/appconfig.json
+++ b/samples/refresh-token-sample-ui5/webapp/appconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "Refresh token sample (SAP UI5)",
-  "provider": "SAP FSM",
-  "description": "Sample extension to demo the refresh token functionality in FSM Shell SDK for SAP UI5 extensions.",   
+  "provider": "SAP SE",
+  "description": "Sample extension to demo the refresh token functionality in SAP Field Service and Asset Management Shell SDK for SAP UI5 extensions.",   
   "version": "1.0.0", 
   "icon": "https://upload.wikimedia.org/wikipedia/commons/d/d3/User_Circle.png"
 }


### PR DESCRIPTION
With the 2605 release, SAP Field Service Management (FSM) has been renamed to SAP Field Service and Asset Management (FSA). While technical designations are not affected at this time, this pull request updated all docs with the new name.
[More information](https://help.sap.com/docs/SAP_FIELD_SERVICE_MANAGEMENT/fsm_product_announcements/introduction-of-sap-field-service-and-asset-management.html)