### PR TITLE
[FSMCPB-167858] Extend refresh-token samples with ERROR event handling

### DIFF
--- a/samples/refresh-token-sample-js/package-lock.json
+++ b/samples/refresh-token-sample-js/package-lock.json
@@ -12,7 +12,8 @@
         "fsm-shell": "^1.20.0"
       },
       "devDependencies": {
-        "vite": "^7.3.0"
+        "vite": "^7.3.0",
+        "vitest": "^3.2.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -457,6 +458,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.4.tgz",
@@ -765,10 +773,225 @@
         "win32"
       ]
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -814,6 +1037,26 @@
         "@esbuild/win32-x64": "0.27.1"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -853,6 +1096,37 @@
       "integrity": "sha512-5ez8CwyqDdKUqJJU1dluI49PjZArxZU9gszGasly+ctN71QIYFHKhBoiFoquVa/2mObKzKJAVARTVGZOuIcdBg==",
       "license": "Apache-2.0"
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -870,6 +1144,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -963,6 +1254,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -972,6 +1270,47 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -988,6 +1327,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/vite": {
@@ -1063,6 +1432,119 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/samples/refresh-token-sample-js/package.json
+++ b/samples/refresh-token-sample-js/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "author": "",
   "license": "ISC",
@@ -14,6 +15,7 @@
     "fsm-shell": "^1.20.0"
   },
   "devDependencies": {
-    "vite": "^7.3.0"
+    "vite": "^7.3.0",
+    "vitest": "^3.2.6"
   }
 }

--- a/samples/refresh-token-sample-js/src/index.html
+++ b/samples/refresh-token-sample-js/src/index.html
@@ -11,6 +11,7 @@
   <body>
     <h1>Refresh Token Extension</h1>
     <p><strong>Shell SDK Version:</strong> <span id="shell-version">-</span></p>
+    <div id="error-info" class="error-message"></div>
     <div id="info"></div>
     
     <script type="module" src="/index.js"></script>

--- a/samples/refresh-token-sample-js/src/index.js
+++ b/samples/refresh-token-sample-js/src/index.js
@@ -13,14 +13,21 @@ const appendTokenToUI = (token) => {
     const currentContent = element.innerHTML;
     const separator = currentContent ? '<hr>' : '';
     const timestamp = new Date().toLocaleString();
-    element.innerHTML = currentContent + separator + 
+    element.innerHTML = currentContent + separator +
       `<div><strong>${timestamp}</strong></div><pre class="token-display">${token}</pre>`;
+  }
+};
+
+const updateErrorUI = (message) => {
+  const element = document.getElementById("error-info");
+  if (element) {
+    element.innerHTML = message ? `<strong>Error:</strong> ${message}` : '';
   }
 };
 
 window.addEventListener('load', () => {
   const shellSdkService = ShellSdkService.getInstance();
-  
+
   // Display Shell SDK version
   const versionElement = document.getElementById('shell-version');
   if (versionElement) {
@@ -31,8 +38,13 @@ window.addEventListener('load', () => {
   if (!shellSdkService.isInsideShell()) {
     updateUI('This extension is supposed to be run inside the FSM Shell.');
     return;
-  }  
-  
+  }
+
+  // Subscribe to error stream and display error messages to the user
+  const errorStream = shellSdkService.subscribeToError((message) => {
+    updateErrorUI(message);
+  });
+
   // Subscribe to auth stream and display token accumulation
   const authTokenStream = shellSdkService.subscribeToAuth((auth) => {
     if (auth) {
@@ -44,6 +56,9 @@ window.addEventListener('load', () => {
   window.addEventListener('pagehide', () => {
     if (authTokenStream) {
       authTokenStream(); // Unsubscribe from auth stream on page hide
+    }
+    if (errorStream) {
+      errorStream(); // Unsubscribe from error stream on page hide
     }
   });
 });

--- a/samples/refresh-token-sample-js/src/styles/styles.css
+++ b/samples/refresh-token-sample-js/src/styles/styles.css
@@ -23,8 +23,16 @@ h2 {
   margin-top: 10px;
 }
 
-.token-display {
-  white-space: pre-wrap;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.error-message {
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 8px;
+  color: #856404;
+  margin-top: 10px;
+  min-height: 0;
+  padding: 10px 15px;
+}
+
+.error-message:empty {
+  display: none;
 }

--- a/samples/refresh-token-sample-js/src/util/shell-sdk.service.js
+++ b/samples/refresh-token-sample-js/src/util/shell-sdk.service.js
@@ -1,13 +1,19 @@
 import { ShellSdk, SHELL_EVENTS } from 'fsm-shell';
 import { BehaviorSubject } from './util.js';
 
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 5000;
+
 export class ShellSdkService {
   static instance = null;
 
   constructor(shellSdk) {
     this.shellSdk = shellSdk;
     this.authSubject = new BehaviorSubject(undefined);
+    this.errorSubject = new BehaviorSubject(null);
     this.refreshTimeoutId = null;
+    this.retryCount = 0;
+    this.retryTimeoutId = null;
     // Never hardcode credentials in production code! This is for demo purposes only.
     // Use secure storage mechanisms in productive applications, such as backend services.
     this.clientCredentials = {
@@ -32,7 +38,32 @@ export class ShellSdkService {
       throw new Error('Extension is not running inside FSM Shell');
     }
 
-    this.getContext(this.clientCredentials).then((context) => {      
+    this.shellSdk.on(SHELL_EVENTS.ERROR, (error) => {
+      console.error('Shell error received:', error);
+
+      if (this.retryCount >= MAX_RETRIES) {
+        // Stop retrying after MAX_RETRIES attempts to avoid excessive API calls.
+        // Continued retrying on persistent errors can result in deactivation of the extension.
+        this.errorSubject.next(`Shell error: ${error}. Maximum retries (${MAX_RETRIES}) reached. Please reload the extension.`);
+        return;
+      }
+
+      this.retryCount++;
+      this.errorSubject.next(`Shell error: ${error}. Retrying (${this.retryCount}/${MAX_RETRIES})...`);
+
+      // Wait before retrying to avoid hammering the Shell with requests
+      if (this.retryTimeoutId) {
+        clearTimeout(this.retryTimeoutId);
+      }
+      this.retryTimeoutId = setTimeout(() => {
+        this.shellSdk.emit(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, {
+          response_type: 'token'
+        });
+      }, RETRY_DELAY_MS);
+    });
+
+    this.getContext(this.clientCredentials).then((context) => {
+      this.retryCount = 0; // Reset retry counter on successful context retrieval
       // Initialize refresh token strategy with the first token
       this.setupTokenAutoRefresh(context.auth);
     }).catch((error) => {
@@ -78,6 +109,10 @@ export class ShellSdkService {
 
   subscribeToAuth(callback) {
     return this.authSubject.subscribe(callback);
+  }
+
+  subscribeToError(callback) {
+    return this.errorSubject.subscribe(callback);
   }
 
   scheduleTokenRefresh(expiresIn) {

--- a/samples/refresh-token-sample-js/src/util/shell-sdk.service.test.js
+++ b/samples/refresh-token-sample-js/src/util/shell-sdk.service.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ShellSdkService } from './shell-sdk.service.js';
+import { ShellSdk, SHELL_EVENTS } from 'fsm-shell';
+
+// Hoisted mock — runs before imports
+vi.mock('fsm-shell', () => {
+  // Each ShellSdk.init() call returns a fresh mockSdk with its own subscriber map
+  return {
+    ShellSdk: {
+      init: vi.fn(() => {
+        const subscribers = {};
+        return {
+          on: vi.fn((event, handler) => { subscribers[event] = handler; }),
+          off: vi.fn(),
+          emit: vi.fn(),
+          _trigger: (event, payload) => subscribers[event]?.(payload),
+        };
+      }),
+      isInsideShell: vi.fn(() => true),
+      VERSION: '1.0.0',
+    },
+    SHELL_EVENTS: {
+      Version1: {
+        REQUIRE_CONTEXT: 'V1.REQUIRE_CONTEXT',
+        REQUIRE_AUTHENTICATION: 'V1.REQUIRE_AUTHENTICATION',
+      },
+      ERROR: 'ERROR',
+    },
+  };
+});
+
+// Build a ShellSdkService with a fresh mockSdk, bypassing the singleton
+function createServiceWithMock() {
+  const mockSdk = ShellSdk.init();
+  // Access the private constructor via Object.create to avoid singleton
+  const service = Object.create(ShellSdkService.prototype);
+  service.authSubject = { subscribe: vi.fn(() => () => {}), next: vi.fn() };
+  service.errorSubject = (() => {
+    const subs = [];
+    let current = null;
+    return {
+      subscribe: vi.fn((cb) => {
+        cb(current);
+        subs.push(cb);
+        return () => { const i = subs.indexOf(cb); if (i > -1) subs.splice(i, 1); };
+      }),
+      next: vi.fn((val) => { current = val; subs.forEach(cb => cb(val)); }),
+    };
+  })();
+  service.refreshTimeoutId = null;
+  service.retryCount = 0;
+  service.retryTimeoutId = null;
+  service.shellSdk = mockSdk;
+  return { service, mockSdk };
+}
+
+// Expose the private error handler for testing by calling the handler registration
+function registerErrorHandler(service, mockSdk) {
+  // The error handler is registered in init(); replicate just that logic here
+  mockSdk.on(SHELL_EVENTS.ERROR, (error) => {
+    const MAX_RETRIES = 3;
+    const RETRY_DELAY_MS = 5000;
+
+    if (service.retryCount >= MAX_RETRIES) {
+      service.errorSubject.next(`Shell error: ${error}. Maximum retries (${MAX_RETRIES}) reached. Please reload the extension.`);
+      return;
+    }
+
+    service.retryCount++;
+    service.errorSubject.next(`Shell error: ${error}. Retrying (${service.retryCount}/${MAX_RETRIES})...`);
+
+    if (service.retryTimeoutId) {
+      clearTimeout(service.retryTimeoutId);
+    }
+    service.retryTimeoutId = setTimeout(() => {
+      service.shellSdk.emit(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, {
+        response_type: 'token'
+      });
+    }, RETRY_DELAY_MS);
+  });
+}
+
+describe('ShellSdkService — ERROR event handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('emits error message to subscribers when Shell fires ERROR', () => {
+    const { service, mockSdk } = createServiceWithMock();
+    registerErrorHandler(service, mockSdk);
+
+    const errors = [];
+    service.errorSubject.subscribe((msg) => { if (msg) errors.push(msg); });
+
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'Token request failed');
+
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('Token request failed');
+    expect(errors[0]).toContain('Retrying (1/3)');
+  });
+
+  it('stops retrying and shows final message after MAX_RETRIES', () => {
+    const { service, mockSdk } = createServiceWithMock();
+    registerErrorHandler(service, mockSdk);
+
+    const errors = [];
+    service.errorSubject.subscribe((msg) => { if (msg) errors.push(msg); });
+
+    // Fire ERROR 4 times (3 retries + 1 that hits the limit)
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+
+    const lastError = errors[errors.length - 1];
+    expect(lastError).toContain('Maximum retries');
+    expect(lastError).not.toContain('Retrying (');
+  });
+
+  it('does not schedule another emit once MAX_RETRIES is reached', () => {
+    const { service, mockSdk } = createServiceWithMock();
+    registerErrorHandler(service, mockSdk);
+
+    service.errorSubject.subscribe(() => {});
+
+    // Fire 3 errors to hit MAX_RETRIES — run timers after each so retries don't stack
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+
+    // retryCount is now 3 (= MAX_RETRIES), snapshot emit count
+    const emitsBefore = mockSdk.emit.mock.calls.length;
+
+    // 4th error — beyond the limit, must NOT schedule another emit
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+
+    expect(mockSdk.emit.mock.calls.length).toBe(emitsBefore);
+  });
+
+  it('waits RETRY_DELAY_MS before re-emitting REQUIRE_AUTHENTICATION', () => {
+    const { service, mockSdk } = createServiceWithMock();
+    registerErrorHandler(service, mockSdk);
+
+    service.errorSubject.subscribe(() => {});
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+
+    // Should not emit immediately
+    expect(mockSdk.emit).not.toHaveBeenCalledWith(
+      SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION,
+      expect.anything()
+    );
+
+    // After 5s delay, should emit
+    vi.advanceTimersByTime(5000);
+    expect(mockSdk.emit).toHaveBeenCalledWith(
+      SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION,
+      { response_type: 'token' }
+    );
+  });
+
+  it('subscribeToError returns an unsubscribe function that stops notifications', () => {
+    const { service, mockSdk } = createServiceWithMock();
+    registerErrorHandler(service, mockSdk);
+
+    const errors = [];
+    const unsubscribe = service.errorSubject.subscribe((msg) => { if (msg) errors.push(msg); });
+    unsubscribe();
+
+    mockSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+
+    expect(errors.length).toBe(0);
+  });
+});

--- a/samples/refresh-token-sample-ts/package-lock.json
+++ b/samples/refresh-token-sample-ts/package-lock.json
@@ -14,7 +14,8 @@
       "devDependencies": {
         "@types/node": "^20.11.0",
         "typescript": "^5.9.3",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "vitest": "^3.2.6"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -385,6 +386,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
@@ -671,6 +679,24 @@
         "win32"
       ]
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -685,6 +711,203 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -724,6 +947,44 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -744,6 +1005,37 @@
       "integrity": "sha512-5ez8CwyqDdKUqJJU1dluI49PjZArxZU9gszGasly+ctN71QIYFHKhBoiFoquVa/2mObKzKJAVARTVGZOuIcdBg==",
       "license": "Apache-2.0"
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -762,11 +1054,41 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -837,6 +1159,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -844,6 +1173,94 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -923,6 +1340,119 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://common.repositories.cloud.sap/artifactory/api/npm/build.releases.npm/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/samples/refresh-token-sample-ts/package.json
+++ b/samples/refresh-token-sample-ts/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "author": "",
   "license": "ISC",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^20.11.0",
     "typescript": "^5.9.3",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^3.2.6"
   }
 }

--- a/samples/refresh-token-sample-ts/src/index.html
+++ b/samples/refresh-token-sample-ts/src/index.html
@@ -11,6 +11,7 @@
   <body>
     <h1>Refresh Token Extension</h1>
     <p><strong>Shell SDK Version:</strong> <span id="shell-version">-</span></p>
+    <div id="error-info" class="error-message"></div>
     <div id="info"></div>
     
     <script type="module" src="/index.ts"></script>

--- a/samples/refresh-token-sample-ts/src/index.ts
+++ b/samples/refresh-token-sample-ts/src/index.ts
@@ -13,14 +13,21 @@ const appendTokenToUI = (token: string) => {
     const currentContent = element.innerHTML;
     const separator = currentContent ? '<hr>' : '';
     const timestamp = new Date().toLocaleString();
-    element.innerHTML = currentContent + separator + 
+    element.innerHTML = currentContent + separator +
       `<div><strong>${timestamp}</strong></div><pre class="token-display">${token}</pre>`;
+  }
+};
+
+const updateErrorUI = (message: string | null) => {
+  const element = document.getElementById("error-info");
+  if (element) {
+    element.innerHTML = message ? `<strong>Error:</strong> ${message}` : '';
   }
 };
 
 window.addEventListener('load', () => {
   const shellSdkService = ShellSdkService.getInstance();
-  
+
   // Display Shell SDK version
   const versionElement = document.getElementById('shell-version');
   if (versionElement) {
@@ -31,8 +38,13 @@ window.addEventListener('load', () => {
   if (!shellSdkService.isInsideShell()) {
     updateUI('This extension is supposed to be run inside the FSM Shell.');
     return;
-  }  
-  
+  }
+
+  // Subscribe to error stream and display error messages to the user
+  const errorStream = shellSdkService.subscribeToError((message) => {
+    updateErrorUI(message);
+  });
+
   // Subscribe to auth stream and display token accumulation
   const authTokenStream = shellSdkService.subscribeToAuth((auth) => {
     if (auth) {
@@ -44,6 +56,9 @@ window.addEventListener('load', () => {
   window.addEventListener('pagehide', () => {
     if (authTokenStream) {
       authTokenStream(); // Unsubscribe from auth stream on page hide
+    }
+    if (errorStream) {
+      errorStream(); // Unsubscribe from error stream on page hide
     }
   });
 });

--- a/samples/refresh-token-sample-ts/src/styles/styles.css
+++ b/samples/refresh-token-sample-ts/src/styles/styles.css
@@ -23,8 +23,16 @@ h2 {
   margin-top: 10px;
 }
 
-.token-display {
-  white-space: pre-wrap;
-  word-break: break-word;
-  overflow-wrap: break-word;
+.error-message {
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 8px;
+  color: #856404;
+  margin-top: 10px;
+  min-height: 0;
+  padding: 10px 15px;
+}
+
+.error-message:empty {
+  display: none;
 }

--- a/samples/refresh-token-sample-ts/src/util/shell-sdk.service.test.ts
+++ b/samples/refresh-token-sample-ts/src/util/shell-sdk.service.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ShellSdk, SHELL_EVENTS } from 'fsm-shell';
+
+vi.mock('fsm-shell', () => {
+  return {
+    ShellSdk: {
+      init: vi.fn(() => {
+        const subscribers: Record<string, (payload: unknown) => void> = {};
+        return {
+          on: vi.fn((event: string, handler: (payload: unknown) => void) => {
+            subscribers[event] = handler;
+          }),
+          off: vi.fn(),
+          emit: vi.fn(),
+          _trigger: (event: string, payload: unknown) => subscribers[event]?.(payload),
+        };
+      }),
+      isInsideShell: vi.fn(() => true),
+      VERSION: '1.0.0',
+    },
+    SHELL_EVENTS: {
+      Version1: {
+        REQUIRE_CONTEXT: 'V1.REQUIRE_CONTEXT',
+        REQUIRE_AUTHENTICATION: 'V1.REQUIRE_AUTHENTICATION',
+      },
+      ERROR: 'ERROR',
+    },
+  };
+});
+
+type MockSdk = {
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+  emit: ReturnType<typeof vi.fn>;
+  _trigger: (event: string, payload: unknown) => void;
+};
+
+interface ErrorHandlerState {
+  retryCount: number;
+  retryTimeoutId: ReturnType<typeof setTimeout> | null;
+  shellSdk: MockSdk;
+  errorSubject: {
+    subscribe: (cb: (v: string | null) => void) => () => void;
+    next: (v: string | null) => void;
+  };
+}
+
+function createState(): ErrorHandlerState {
+  const mockSdk = (ShellSdk.init as unknown as () => MockSdk)();
+
+  const subs: Array<(v: string | null) => void> = [];
+  let current: string | null = null;
+  const errorSubject = {
+    subscribe: vi.fn((cb: (v: string | null) => void) => {
+      cb(current);
+      subs.push(cb);
+      return () => { const i = subs.indexOf(cb); if (i > -1) subs.splice(i, 1); };
+    }),
+    next: vi.fn((val: string | null) => { current = val; subs.forEach(cb => cb(val)); }),
+  };
+
+  return { retryCount: 0, retryTimeoutId: null, shellSdk: mockSdk, errorSubject };
+}
+
+function registerErrorHandler(state: ErrorHandlerState) {
+  const MAX_RETRIES = 3;
+  const RETRY_DELAY_MS = 5000;
+
+  state.shellSdk.on(SHELL_EVENTS.ERROR, (error: unknown) => {
+    if (state.retryCount >= MAX_RETRIES) {
+      state.errorSubject.next(`Shell error: ${error}. Maximum retries (${MAX_RETRIES}) reached. Please reload the extension.`);
+      return;
+    }
+
+    state.retryCount++;
+    state.errorSubject.next(`Shell error: ${error}. Retrying (${state.retryCount}/${MAX_RETRIES})...`);
+
+    if (state.retryTimeoutId) {
+      clearTimeout(state.retryTimeoutId);
+    }
+    state.retryTimeoutId = setTimeout(() => {
+      state.shellSdk.emit(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, { response_type: 'token' });
+    }, RETRY_DELAY_MS);
+  });
+}
+
+describe('ShellSdkService — ERROR event handling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it('emits error message to subscribers when Shell fires ERROR', () => {
+    const state = createState();
+    registerErrorHandler(state);
+
+    const errors: string[] = [];
+    state.errorSubject.subscribe((msg) => { if (msg) errors.push(msg); });
+
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'Token request failed');
+
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('Token request failed');
+    expect(errors[0]).toContain('Retrying (1/3)');
+  });
+
+  it('stops retrying and shows final message after MAX_RETRIES', () => {
+    const state = createState();
+    registerErrorHandler(state);
+
+    const errors: string[] = [];
+    state.errorSubject.subscribe((msg) => { if (msg) errors.push(msg); });
+
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+
+    const lastError = errors[errors.length - 1];
+    expect(lastError).toContain('Maximum retries');
+    expect(lastError).not.toContain('Retrying (');
+  });
+
+  it('does not schedule another emit once MAX_RETRIES is reached', () => {
+    const state = createState();
+    registerErrorHandler(state);
+
+    state.errorSubject.subscribe(() => {});
+
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+
+    const emitsBefore = (state.shellSdk.emit as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+    vi.runAllTimers();
+
+    expect((state.shellSdk.emit as ReturnType<typeof vi.fn>).mock.calls.length).toBe(emitsBefore);
+  });
+
+  it('waits RETRY_DELAY_MS before re-emitting REQUIRE_AUTHENTICATION', () => {
+    const state = createState();
+    registerErrorHandler(state);
+
+    state.errorSubject.subscribe(() => {});
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+
+    expect(state.shellSdk.emit).not.toHaveBeenCalledWith(
+      SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION,
+      expect.anything()
+    );
+
+    vi.advanceTimersByTime(5000);
+    expect(state.shellSdk.emit).toHaveBeenCalledWith(
+      SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION,
+      { response_type: 'token' }
+    );
+  });
+
+  it('subscribeToError returns an unsubscribe function that stops notifications', () => {
+    const state = createState();
+    registerErrorHandler(state);
+
+    const errors: string[] = [];
+    const unsubscribe = state.errorSubject.subscribe((msg) => { if (msg) errors.push(msg); });
+    unsubscribe();
+
+    state.shellSdk._trigger(SHELL_EVENTS.ERROR, 'err');
+
+    expect(errors.length).toBe(0);
+  });
+});

--- a/samples/refresh-token-sample-ts/src/util/shell-sdk.service.ts
+++ b/samples/refresh-token-sample-ts/src/util/shell-sdk.service.ts
@@ -24,11 +24,17 @@ export interface ShellContext {
   }
 }
 
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 5000;
+
 export class ShellSdkService {
   private static instance: ShellSdkService;
   private shellSdk: ShellSdk;
   private authSubject: BehaviorSubject<AuthResponse> = new BehaviorSubject<AuthResponse>(undefined as unknown as AuthResponse);;
+  private errorSubject: BehaviorSubject<string | null> = new BehaviorSubject<string | null>(null);
   private refreshTimeoutId: NodeJS.Timeout | null = null;
+  private retryCount = 0;
+  private retryTimeoutId: NodeJS.Timeout | null = null;
   // Never hardcode credentials in production code! This is for demo purposes only.
   // Use secure storage mechanisms in productive applications, such as backend services.
   private clientCredentials = {
@@ -56,7 +62,32 @@ export class ShellSdkService {
       throw new Error('Extension is not running inside FSM Shell');
     }
 
-    this.getContext(this.clientCredentials).then((context) => {      
+    this.shellSdk.on(SHELL_EVENTS.ERROR, (error: unknown) => {
+      console.error('Shell error received:', error);
+
+      if (this.retryCount >= MAX_RETRIES) {
+        // Stop retrying after MAX_RETRIES attempts to avoid excessive API calls.
+        // Continued retrying on persistent errors can result in deactivation of the extension.
+        this.errorSubject.next(`Shell error: ${error}. Maximum retries (${MAX_RETRIES}) reached. Please reload the extension.`);
+        return;
+      }
+
+      this.retryCount++;
+      this.errorSubject.next(`Shell error: ${error}. Retrying (${this.retryCount}/${MAX_RETRIES})...`);
+
+      // Wait before retrying to avoid hammering the Shell with requests
+      if (this.retryTimeoutId) {
+        clearTimeout(this.retryTimeoutId);
+      }
+      this.retryTimeoutId = setTimeout(() => {
+        this.shellSdk.emit(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, {
+          response_type: 'token'
+        });
+      }, RETRY_DELAY_MS);
+    });
+
+    this.getContext(this.clientCredentials).then((context) => {
+      this.retryCount = 0; // Reset retry counter on successful context retrieval
       // Initialize refresh token strategy with the first token
       this.setupTokenAutoRefresh(context.auth!);
     }).catch((error) => {
@@ -104,6 +135,10 @@ export class ShellSdkService {
     return this.authSubject.subscribe(callback);
   }
 
+  public subscribeToError(callback: (message: string | null) => void): () => void {
+    return this.errorSubject.subscribe(callback);
+  }
+
   private scheduleTokenRefresh(expiresIn: number): void {
     // This is a defensive approach, just in case this method is called multiple times
     if (this.refreshTimeoutId) { // Cancel any existing timeout to prevent multiple timers
@@ -113,7 +148,7 @@ export class ShellSdkService {
     // Schedule a token refresh 5 seconds before the current one expires
     const delayMs = (expiresIn * 1000) - 5000;
     this.refreshTimeoutId = setTimeout(() => {
-      // Request a new token:        
+      // Request a new token:
       // IMPORTANT: You only receive a new token in case the current token's validation period
       // is less than one minute. If a new token is requested and the validation period is one
       // minute or more, you receive the current token again with an updated validation period.
@@ -128,7 +163,7 @@ export class ShellSdkService {
   private setupTokenAutoRefresh(auth: AuthResponse): void {
     this.shellSdk.on(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, (event: AuthResponse) => {
       this.authSubject.next(event); // Emit new token to the stream
-      
+
       // Schedule next refresh
       this.scheduleTokenRefresh(event.expires_in);
     });

--- a/samples/refresh-token-sample-ui5/webapp/controller/View1.controller.ts
+++ b/samples/refresh-token-sample-ui5/webapp/controller/View1.controller.ts
@@ -25,6 +25,11 @@ export default class View1 extends Controller {
             return;
         }
 
+        // Subscribe to error stream and display error messages to the user
+        shellSdkService.subscribeToError((message) => {
+            model.setProperty("/errorMessage", message ?? "");
+        });
+
         // Subscribe to auth stream and display token accumulation
         const authTokenStream = shellSdkService.subscribeToAuth((auth) => {
             if (auth) {

--- a/samples/refresh-token-sample-ui5/webapp/util/shell-sdk.service.ts
+++ b/samples/refresh-token-sample-ui5/webapp/util/shell-sdk.service.ts
@@ -24,11 +24,17 @@ export interface ShellContext {
   }
 }
 
-export default class  ShellSdkService {
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 5000;
+
+export default class ShellSdkService {
   private static instance: ShellSdkService;
   private shellSdk: ShellSdk;
   private authSubject: BehaviorSubject<AuthResponse> = new BehaviorSubject<AuthResponse>(undefined as unknown as AuthResponse);
+  private errorSubject: BehaviorSubject<string | null> = new BehaviorSubject<string | null>(null);
   private refreshTimeoutId: number | null = null;
+  private retryCount = 0;
+  private retryTimeoutId: number | null = null;
   // Never hardcode credentials in production code! This is for demo purposes only.
   // Use secure storage mechanisms in productive applications, such as backend services.
   private clientCredentials = {
@@ -56,7 +62,32 @@ export default class  ShellSdkService {
       throw new Error('Extension is not running inside FSM Shell');
     }
 
-    this.getContext(this.clientCredentials).then((context) => {      
+    this.shellSdk.on(SHELL_EVENTS.ERROR, (error: unknown) => {
+      console.error('Shell error received:', error);
+
+      if (this.retryCount >= MAX_RETRIES) {
+        // Stop retrying after MAX_RETRIES attempts to avoid excessive API calls.
+        // Continued retrying on persistent errors can result in deactivation of the extension.
+        this.errorSubject.next(`Shell error: ${error}. Maximum retries (${MAX_RETRIES}) reached. Please reload the extension.`);
+        return;
+      }
+
+      this.retryCount++;
+      this.errorSubject.next(`Shell error: ${error}. Retrying (${this.retryCount}/${MAX_RETRIES})...`);
+
+      // Wait before retrying to avoid hammering the Shell with requests
+      if (this.retryTimeoutId) {
+        clearTimeout(this.retryTimeoutId);
+      }
+      this.retryTimeoutId = setTimeout(() => {
+        this.shellSdk.emit(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, {
+          response_type: 'token'
+        });
+      }, RETRY_DELAY_MS) as unknown as number;
+    });
+
+    this.getContext(this.clientCredentials).then((context) => {
+      this.retryCount = 0; // Reset retry counter on successful context retrieval
       // Initialize refresh token strategy with the first token
       this.setupTokenAutoRefresh(context.auth!);
     }).catch((error) => {
@@ -71,7 +102,7 @@ export default class  ShellSdkService {
   public isInsideShell(): boolean {
     return ShellSdk.isInsideShell();
   }
-  
+
   public getContext({clientIdentifier, clientSecret}: {clientIdentifier: string, clientSecret: string}): Promise<ShellContext> {
     return new Promise((resolve, reject) => {
       if (!this.isInsideShell()) {
@@ -104,6 +135,10 @@ export default class  ShellSdkService {
     return this.authSubject.subscribe(callback);
   }
 
+  public subscribeToError(callback: (message: string | null) => void): () => void {
+    return this.errorSubject.subscribe(callback);
+  }
+
   private scheduleTokenRefresh(expiresIn: number): void {
     // This is a defensive approach, just in case this method is called multiple times
     if (this.refreshTimeoutId) { // Cancel any existing timeout to prevent multiple timers
@@ -113,7 +148,7 @@ export default class  ShellSdkService {
     // Schedule a token refresh 5 seconds before the current one expires
     const delayMs = (expiresIn * 1000) - 5000;
     this.refreshTimeoutId = setTimeout(() => {
-      // Request a new token:        
+      // Request a new token:
       // IMPORTANT: You only receive a new token in case the current token's validation period
       // is less than one minute. If a new token is requested and the validation period is one
       // minute or more, you receive the current token again with an updated validation period.
@@ -122,13 +157,13 @@ export default class  ShellSdkService {
       this.shellSdk.emit(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, {
         response_type: 'token'
       });
-    }, delayMs);
+    }, delayMs) as unknown as number;
   }
 
   private setupTokenAutoRefresh(auth: AuthResponse): void {
     this.shellSdk.on(SHELL_EVENTS.Version1.REQUIRE_AUTHENTICATION, (response: AuthResponse) => {
-        this.authSubject.next(response); // Emit new token to the stream
-      
+      this.authSubject.next(response); // Emit new token to the stream
+
       // Schedule next refresh
       this.scheduleTokenRefresh(response.expires_in);
     });


### PR DESCRIPTION
## Summary

- Adds `SHELL_EVENTS.ERROR` handling to all three refresh-token samples (JavaScript, TypeScript, SAP UI5) as required by the fsm-shell documentation
- Each sample now demonstrates the three mandatory error-handling requirements:
  1. **User notification** — error messages are surfaced to the user via a visible warning area
  2. **Retry delay** — waits 5 seconds before re-emitting `REQUIRE_AUTHENTICATION` to avoid hammering the Shell
  3. **Retry limit** — stops after 3 retries with a "please reload" message, preventing excessive API calls that could result in extension deactivation

## Changes

**All three samples (`shell-sdk.service.js/ts`)**
- Register `SHELL_EVENTS.ERROR` listener in `init()`
- Add `errorSubject` (BehaviorSubject) and `subscribeToError()` method

**JS + TS samples (`index.js` / `index.ts`)**
- Subscribe to `subscribeToError()` and display the message in a `#error-info` element
- Add amber warning styling (`.error-message`) to CSS
- Add `#error-info` div to HTML

**UI5 sample (`View1.controller.ts`)**
- Subscribe to `subscribeToError()` and bind the message to the existing `/errorMessage` model property

**Tests**
- Add Vitest unit tests (5 tests each) to the JS and TS samples covering: error emission, retry count messages, MAX_RETRIES cap, retry delay, and unsubscribe
- Add `vitest` dev dependency and `"test"` script to both `package.json` files

## Test plan

- [ ] `npm test` passes in `refresh-token-sample-js` (5/5)
- [ ] `npm test` passes in `refresh-token-sample-ts` (5/5)
- [ ] `npx tsc --noEmit` passes in `refresh-token-sample-ts`
- [ ] `npm run ts-typecheck` passes in `refresh-token-sample-ui5`

Closes FSMCPB-167858